### PR TITLE
ENH Add docblocks, method types, tidy up unit tests

### DIFF
--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -2,14 +2,12 @@
 
 namespace SilverStripe\SessionManager\Extensions;
 
-use SilverStripe\Control\Controller;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_Base;
 use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Security;
@@ -21,6 +19,9 @@ class MemberExtension extends Extension implements PermissionProvider
 {
     public const SESSION_MANAGER_ADMINISTER_SESSIONS = 'SESSION_MANAGER_ADMINISTER_SESSIONS';
 
+    /**
+     * @var array
+     */
     private static $has_many = [
         'LoginSessions' => LoginSession::class
     ];
@@ -77,7 +78,7 @@ class MemberExtension extends Extension implements PermissionProvider
     /**
      * @return int
      */
-    protected function getSessionLifetime()
+    private function getSessionLifetime(): int
     {
         if ($lifetime = Session::config()->get('timeout')) {
             return $lifetime;

--- a/src/Extension/RememberLoginHashExtension.php
+++ b/src/Extension/RememberLoginHashExtension.php
@@ -10,17 +10,26 @@ use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
 
 class RememberLoginHashExtension extends Extension
 {
+    /**
+     * @var array
+     */
     private static $has_one = [
         'LoginSession' => LoginSession::class
     ];
 
-    public function onAfterGenerateToken()
+    /**
+     * @return void
+     */
+    public function onAfterGenerateToken(): void
     {
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $loginHandler->setRememberLoginHash($this->owner);
     }
 
-    public function onAfterRenewToken()
+    /**
+     * @return void
+     */
+    public function onAfterRenewToken(): void
     {
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $request = Injector::inst()->get(HTTPRequest::class);

--- a/src/Forms/GridFieldRevokeLoginSessionAction.php
+++ b/src/Forms/GridFieldRevokeLoginSessionAction.php
@@ -9,19 +9,19 @@ use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
 use SilverStripe\Forms\GridField\GridField_FormAction;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
 use SilverStripe\View\Requirements;
 
-/**
- * Class GridFieldRevokeLoginSessionAction
- * @package SilverStripe\SessionManager\Forms
- * @codeCoverageIgnore
- */
 class GridFieldRevokeLoginSessionAction implements GridField_ColumnProvider, GridField_ActionProvider
 {
     use Injectable;
 
+    /**
+     * @param GridField $gridField
+     * @param array $columns
+     */
     public function augmentColumns($gridField, &$columns)
     {
         if (!in_array('Actions', $columns)) {
@@ -29,11 +29,22 @@ class GridFieldRevokeLoginSessionAction implements GridField_ColumnProvider, Gri
         }
     }
 
+    /**
+     * @param GridField $gridField
+     * @param DataObject $record
+     * @param string $columnName
+     * @return array
+     */
     public function getColumnAttributes($gridField, $record, $columnName)
     {
         return ['class' => 'grid-field__col-compact'];
     }
 
+    /**
+     * @param GridField $gridField
+     * @param string $columnName
+     * @return array
+     */
     public function getColumnMetadata($gridField, $columnName)
     {
         if ($columnName == 'Actions') {
@@ -41,16 +52,30 @@ class GridFieldRevokeLoginSessionAction implements GridField_ColumnProvider, Gri
         }
     }
 
+    /**
+     * @param GridField $gridField
+     * @return array
+     */
     public function getColumnsHandled($gridField)
     {
         return ['Actions'];
     }
 
+    /**
+     * @param GridField
+     * @return array
+     */
     public function getActions($gridField)
     {
         return ['revoke'];
     }
 
+    /**
+     * @param GridField $gridField
+     * @param DataObject $record
+     * @param string $columnName
+     * @return string
+     */
     public function getColumnContent($gridField, $record, $columnName)
     {
         Requirements::javascript(
@@ -81,9 +106,21 @@ class GridFieldRevokeLoginSessionAction implements GridField_ColumnProvider, Gri
         return $field->Field();
     }
 
+    /**
+     * @param GridField $gridField
+     * @param string $actionName
+     * @param array $arguments
+     * @param array $data
+     * @throws ValidationException
+     */
     public function handleAction(GridField $gridField, $actionName, $arguments, $data)
     {
-        $item = $gridField->getList()->byID($arguments['RecordID']);
+        /** @var DataList $list */
+        $list = $gridField->getList();
+        if (!($list instanceof DataList)) {
+            return;
+        }
+        $item = $list->byID($arguments['RecordID']);
         if (!$item) {
             return;
         }

--- a/src/Middleware/LoginSessionMiddleware.php
+++ b/src/Middleware/LoginSessionMiddleware.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\SessionManager\Control;
 
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\Connect\DatabaseException;
@@ -14,6 +15,11 @@ use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
 
 class LoginSessionMiddleware implements HTTPMiddleware
 {
+    /**
+     * @param HTTPRequest $request
+     * @param callable $delegate
+     * @return HTTPResponse
+     */
     public function process(HTTPRequest $request, callable $delegate)
     {
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);

--- a/src/Security/LogInAuthenticationHandler.php
+++ b/src/Security/LogInAuthenticationHandler.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SessionManager\Security;
 
+use InvalidArgumentException;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -19,12 +20,12 @@ class LogInAuthenticationHandler implements AuthenticationHandler
     /**
      * @var string
      */
-    protected $sessionVariable;
+    private $sessionVariable;
 
     /**
      * @var RememberLoginHash
      */
-    protected $rememberLoginHash;
+    private $rememberLoginHash;
 
     /**
      * @return string
@@ -36,16 +37,17 @@ class LogInAuthenticationHandler implements AuthenticationHandler
 
     /**
      * @param string $sessionVariable
+     * @return void
      */
-    public function setSessionVariable($sessionVariable)
+    public function setSessionVariable(string $sessionVariable): void
     {
         $this->sessionVariable = $sessionVariable;
     }
 
     /**
-     * @return string
+     * @return RememberLoginHash|null
      */
-    public function getRememberLoginHash()
+    public function getRememberLoginHash(): ?RememberLoginHash
     {
         return $this->rememberLoginHash;
     }
@@ -58,10 +60,21 @@ class LogInAuthenticationHandler implements AuthenticationHandler
         $this->rememberLoginHash = $rememberLoginHash;
     }
 
+    /**
+     * @param HTTPRequest $request
+     * @return Member|null
+     */
     public function authenticateRequest(HTTPRequest $request)
     {
+        // noop
     }
 
+    /**
+     * @param Member $member
+     * @param bool $persistent
+     * @param HTTPRequest|null $request
+     * @throws InvalidArgumentException
+     */
     public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
     {
         // Fall back to retrieving request from current Controller if available
@@ -92,7 +105,11 @@ class LogInAuthenticationHandler implements AuthenticationHandler
         $request->getSession()->set($this->getSessionVariable(), $loginSession->ID);
     }
 
+    /**
+     * @param HTTPRequest $request|null
+     */
     public function logOut(HTTPRequest $request = null)
     {
+        // noop
     }
 }

--- a/src/Security/LogOutAuthenticationHandler.php
+++ b/src/Security/LogOutAuthenticationHandler.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SessionManager\Security;
 
+use InvalidArgumentException;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
@@ -17,14 +18,30 @@ use SilverStripe\SessionManager\Model\LoginSession;
  */
 class LogOutAuthenticationHandler implements AuthenticationHandler
 {
+    /**
+     * @param HTTPRequest $request
+     * @return Member|null
+     * @throws ValidationException
+     */
     public function authenticateRequest(HTTPRequest $request)
     {
+        // noop
     }
 
+    /**
+     * @param Member $member
+     * @param bool $persistent
+     * @param HTTPRequest $request|null
+     */
     public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
     {
+        // noop
     }
 
+    /**
+     * @param HTTPRequest $request|null
+     * @throws InvalidArgumentException
+     */
     public function logOut(HTTPRequest $request = null)
     {
         // Fall back to retrieving request from current Controller if available

--- a/src/Service/GarbageCollectionService.php
+++ b/src/Service/GarbageCollectionService.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\SessionManager\Service;
 
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\SessionManager\Model\LoginSession;
@@ -11,7 +10,10 @@ class GarbageCollectionService
 {
     use Injectable;
 
-    public function collect()
+    /**
+     * Delete expired LoginSession and RememberLoginHash records
+     */
+    public function collect(): void
     {
         $this->collectExpiredSessions();
         $this->collectImplicitlyExpiredSessions();
@@ -21,9 +23,9 @@ class GarbageCollectionService
     /**
      * Collect all non-persistent LoginSession records that are older than the session lifetime
      */
-    protected function collectExpiredSessions()
+    private function collectExpiredSessions(): void
     {
-        $lifetime = Config::inst()->get(LoginSession::class, 'default_session_lifetime');
+        $lifetime = LoginSession::config()->get('default_session_lifetime');
         $sessions = LoginSession::get()->filter([
             'LastAccessed:LessThan' => date('Y-m-d H:i:s', time() - $lifetime),
             'Persistent' => 0
@@ -34,23 +36,21 @@ class GarbageCollectionService
     /**
      * Collect all persistent LoginSession records where the associated RememberLoginHash has expired
      */
-    protected function collectImplicitlyExpiredSessions()
+    private function collectImplicitlyExpiredSessions(): void
     {
-        $sessions = LoginSession::get()->filter([
+        LoginSession::get()->filter([
             'Persistent' => 1,
             'LoginHash.ExpiryDate:LessThan' => date('Y-m-d H:i:s')
-        ]);
-        $sessions->removeAll();
+        ])->removeAll();
     }
 
     /**
      * Collect all RememberLoginHash records that have expired
      */
-    protected function collectExpiredLoginHashes()
+    private function collectExpiredLoginHashes(): void
     {
-        $hashes = RememberLoginHash::get()->filter([
+        RememberLoginHash::get()->filter([
             'ExpiryDate:LessThan' => date('Y-m-d H:i:s')
-        ]);
-        $hashes->removeAll();
+        ])->removeAll();
     }
 }

--- a/src/Tasks/GarbageCollectionTask.php
+++ b/src/Tasks/GarbageCollectionTask.php
@@ -5,22 +5,29 @@ namespace SilverStripe\Tasks;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\SessionManager\Service\GarbageCollectionService;
 
-/**
- * Class GarbageCollectionTask
- * @package SilverStripe\Tasks
- * @codeCoverageIgnore
- */
 class GarbageCollectionTask extends BuildTask
 {
+    /**
+     * @var string
+     */
     private static $segment = 'LoginSessionGarbageCollectionTask';
 
+    /**
+     * @var string
+     */
     protected $title = 'Login Session Garbage Collection Task';
 
+    /**
+     * @var string
+     */
     protected $description = 'Removes expired login sessions and “remember me” hashes from the database';
 
+    /**
+     * @param HTTPRequest $request
+     */
     public function run($request)
     {
         GarbageCollectionService::singleton()->collect();
-        echo "Garbage collection completed successfully";
+        echo "Garbage collection completed successfully\n";
     }
 }

--- a/tests/php/Control/LoginSessionMiddlewareTest.php
+++ b/tests/php/Control/LoginSessionMiddlewareTest.php
@@ -16,8 +16,6 @@ class LoginSessionMiddlewareTest extends SapphireTest
 {
     use HttpRequestMockBuilder;
 
-    protected $usesDatabase = true;
-
     protected static $fixture_file = 'LoginSessionMiddlewareTest.yml';
 
     public function testMiddlewareUpdatesLoginSession()
@@ -25,16 +23,15 @@ class LoginSessionMiddlewareTest extends SapphireTest
         // log out
         Security::setCurrentUser(null);
 
-        $sessionID = $this->idFromFixture(LoginSession::class, '1');
+        $sessionID = $this->objFromFixture(LoginSession::class, 'x1')->ID;
         $session = new Session(['activeLoginSession' => $sessionID]);
         $request = $this->buildRequestMock('/', [], [], null, $session);
         $request->method('getIP')->willReturn('192.168.0.1');
-
         $middleware = new LoginSessionMiddleware(new Url('no-match'));
         $next = false;
         $middleware->process(
             $request,
-            static function () use (&$next) {
+            function () use (&$next) {
                 $next = true;
             }
         );
@@ -49,7 +46,7 @@ class LoginSessionMiddlewareTest extends SapphireTest
         $next = false;
         $middleware->process(
             $request,
-            static function () use (&$next) {
+            function () use (&$next) {
                 $next = true;
             }
         );
@@ -74,7 +71,7 @@ class LoginSessionMiddlewareTest extends SapphireTest
 
     public function testMiddlewareSessionRevoked()
     {
-        $sessionID = $this->idFromFixture(LoginSession::class, '1');
+        $sessionID = $this->objFromFixture(LoginSession::class, 'x1')->ID;
         $session = new Session(['activeLoginSession' => $sessionID]);
         $request = $this->buildRequestMock('/', [], [], null, $session);
         $request->method('getIP')->willReturn('192.168.0.1');
@@ -90,7 +87,7 @@ class LoginSessionMiddlewareTest extends SapphireTest
         $next = false;
         $middleware->process(
             $request,
-            static function () use (&$next) {
+            function () use (&$next) {
                 $next = true;
             }
         );
@@ -103,7 +100,7 @@ class LoginSessionMiddlewareTest extends SapphireTest
 
     public function testMiddlewareSessionWrongMember()
     {
-        $sessionID = $this->idFromFixture(LoginSession::class, '1');
+        $sessionID = $this->objFromFixture(LoginSession::class, 'x1')->ID;
         $session = new Session(['activeLoginSession' => $sessionID]);
         $request = $this->buildRequestMock('/', [], [], null, $session);
         $request->method('getIP')->willReturn('192.168.0.1');
@@ -117,7 +114,7 @@ class LoginSessionMiddlewareTest extends SapphireTest
         $next = false;
         $middleware->process(
             $request,
-            static function () use (&$next) {
+            function () use (&$next) {
                 $next = true;
             }
         );

--- a/tests/php/Control/LoginSessionMiddlewareTest.yml
+++ b/tests/php/Control/LoginSessionMiddlewareTest.yml
@@ -7,8 +7,7 @@ SilverStripe\Security\Member:
     Email: 'garion@example.org'
 
 SilverStripe\SessionManager\Model\LoginSession:
-  1:
+  x1:
     LastAccessed: '2003-02-15 10:00:00'
     IPAddress: '192.168.0.1'
     Member: =>SilverStripe\Security\Member.member1
-

--- a/tests/php/Security/LogInAuthenticationHandlerTest.php
+++ b/tests/php/Security/LogInAuthenticationHandlerTest.php
@@ -14,8 +14,6 @@ use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
 
 class LogInAuthenticationHandlerTest extends SapphireTest
 {
-    protected $usesDatabase = true;
-
     protected static $fixture_file = 'LogInAuthenticationHandlerTest.yml';
 
     public function testLogin()

--- a/tests/php/Security/LogOutAuthenticationHandlerTest.php
+++ b/tests/php/Security/LogOutAuthenticationHandlerTest.php
@@ -2,14 +2,11 @@
 
 namespace SilverStripe\SessionManager\Tests\Security;
 
-use SilverStripe\Control\Middleware\ConfirmationMiddleware\Url;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\Tests\HttpRequestMockBuilder;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-use SilverStripe\SessionManager\Control\LoginSessionMiddleware;
 use SilverStripe\SessionManager\Model\LoginSession;
 use SilverStripe\SessionManager\Security\LogOutAuthenticationHandler;
 
@@ -17,13 +14,11 @@ class LogOutAuthenticationHandlerTest extends SapphireTest
 {
     use HttpRequestMockBuilder;
 
-    protected $usesDatabase = true;
-
     protected static $fixture_file = 'LogOutAuthenticationHandlerTest.yml';
 
     public function testLogout()
     {
-        $sessionID = $this->idFromFixture(LoginSession::class, '1');
+        $sessionID = $this->objFromFixture(LoginSession::class, 'x1')->ID;
         $session = new Session(['activeLoginSession' => $sessionID]);
         $request = $this->buildRequestMock('/', [], [], null, $session);
         $request->method('getIP')->willReturn('192.168.0.1');

--- a/tests/php/Security/LogOutAuthenticationHandlerTest.yml
+++ b/tests/php/Security/LogOutAuthenticationHandlerTest.yml
@@ -4,7 +4,7 @@ SilverStripe\Security\Member:
     Email: 'andre@example.org'
 
 SilverStripe\SessionManager\Model\LoginSession:
-  1:
+  x1:
     LastAccessed: '2003-02-15 10:00:00'
     IPAddress: '192.168.0.1'
     Member: =>SilverStripe\Security\Member.member1

--- a/tests/php/Service/GarbageCollectionServiceTest.php
+++ b/tests/php/Service/GarbageCollectionServiceTest.php
@@ -2,25 +2,15 @@
 
 namespace SilverStripe\SessionManager\Tests\Service;
 
-use SilverStripe\CampaignAdmin\SiteTreeExtension;
-use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Control\Middleware\ConfirmationMiddleware\Url;
-use SilverStripe\Control\Session;
-use SilverStripe\Control\Tests\HttpRequestMockBuilder;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\RememberLoginHash;
-use SilverStripe\Security\Security;
-use SilverStripe\SessionManager\Control\LoginSessionMiddleware;
 use SilverStripe\SessionManager\Extensions\RememberLoginHashExtension;
 use SilverStripe\SessionManager\Model\LoginSession;
 use SilverStripe\SessionManager\Service\GarbageCollectionService;
 
 class GarbageCollectionServiceTest extends SapphireTest
 {
-    protected $usesDatabase = true;
-
     protected static $fixture_file = 'GarbageCollectionServiceTest.yml';
 
     protected static $required_extensions = [
@@ -33,22 +23,23 @@ class GarbageCollectionServiceTest extends SapphireTest
     {
         DBDatetime::set_mock_now('2003-08-15 12:00:00');
 
+        $id1 = $this->objFromFixture(LoginSession::class, 'x1')->ID;
+        $id2 = $this->objFromFixture(LoginSession::class, 'x2')->ID;
+        $id3 = $this->objFromFixture(LoginSession::class, 'x3')->ID;
+
         $garbageCollectionService = new GarbageCollectionService();
         $garbageCollectionService->collect();
 
-        $loginSession = LoginSession::get()->byID(1);
         $this->assertNull(
-            $loginSession,
+            LoginSession::get()->byID($id1),
             "Expired login session is deleted"
         );
-        $loginSession = LoginSession::get()->byID(2);
         $this->assertNull(
-            $loginSession,
+            LoginSession::get()->byID($id2),
             "Expired persistent login hash session is deleted"
         );
-        $loginSession = LoginSession::get()->byID(3);
         $this->assertNotNull(
-            $loginSession,
+            LoginSession::get()->byID($id3),
             "Valid login session is not deleted"
         );
     }

--- a/tests/php/Service/GarbageCollectionServiceTest.yml
+++ b/tests/php/Service/GarbageCollectionServiceTest.yml
@@ -1,16 +1,13 @@
 SilverStripe\SessionManager\Model\LoginSession:
-  1:
-    ID: 1
+  x1:
     LastAccessed: '2003-02-15 10:00:00'
     IPAddress: '192.168.0.1'
     Persistent: false
-  2:
-    ID: 2
+  x2:
     LastAccessed: '2003-02-15 10:00:00'
     IPAddress: '192.168.0.1'
     Persistent: true
-  3:
-    ID: 3
+  x3:
     LastAccessed: '2004-02-15 10:00:00'
     IPAddress: '192.168.10.1'
     Persistent: true
@@ -18,4 +15,4 @@ SilverStripe\SessionManager\Model\LoginSession:
 SilverStripe\Security\RememberLoginHash:
   loginHash:
     ExpiryDate: '2003-05-15 10:00:00'
-    LoginSession: =>SilverStripe\SessionManager\Model\LoginSession.2
+    LoginSession: =>SilverStripe\SessionManager\Model\LoginSession.x2


### PR DESCRIPTION
- Added php7 style param types and return types to methods that weren't implementing and old php5 interface
- Added docblocks to properties and methods, including matches php5 docblocks on interfaces
- Tidy up unit tests and fixtures a little
- Add Injectable and Configurable traits where applicable
- Change protected methods to private methods to reduce API footprint
