### PR TITLE
NEW Add onBeforeRemoveLoginSession extension hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "symbiote/silverstripe-queuedjobs": "^4"
     },
     "suggest": {
-        "symbiote/silverstripe-queuedjobs": "^4"
+        "symbiote/silverstripe-queuedjobs": "^4",
+        "silverstripe/auditor": "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Middleware/LoginSessionController.php
+++ b/src/Middleware/LoginSessionController.php
@@ -5,21 +5,15 @@ namespace SilverStripe\SessionManager\Control;
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\ValidationException;
-use SilverStripe\Security\Member;
-use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
 use SilverStripe\SessionManager\Model\LoginSession;
 
-/**
- * Class LoginSessionController
- * @package SilverStripe\SessionManager\Control
- */
+// TODO: move this to Controllers folder and extend Controller instead of LeftAndMain
 class LoginSessionController extends LeftAndMain
 {
     private static $url_segment = 'loginsession';
 
+    // TODO: remove this when no longer extending LeftAndMain
     private static $ignore_menuitem = true;
 
     private static $url_handlers = [
@@ -61,6 +55,8 @@ class LoginSessionController extends LeftAndMain
                 400
             );
         }
+
+        $this->extend('onBeforeRemoveLoginSession', $loginSession);
 
         $loginSession->delete();
 

--- a/src/Security/LogInAuthenticationHandler.php
+++ b/src/Security/LogInAuthenticationHandler.php
@@ -94,7 +94,7 @@ class LogInAuthenticationHandler implements AuthenticationHandler
         }
 
         $loginSession->LastAccessed = DBDatetime::now()->Rfc2822();
-        $loginSession->IPAddress = $request->getIP();
+        $loginSession->IPAddress = $request ? $request->getIP() : '';
         $loginSession->write();
 
         if ($persistent && $rememberLoginHash = $this->getRememberLoginHash()) {
@@ -102,7 +102,9 @@ class LogInAuthenticationHandler implements AuthenticationHandler
             $rememberLoginHash->write();
         }
 
-        $request->getSession()->set($this->getSessionVariable(), $loginSession->ID);
+        if ($request) {
+            $request->getSession()->set($this->getSessionVariable(), $loginSession->ID);
+        }
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-session-manager/issues/20

Related: https://github.com/silverstripe/silverstripe-auditor/pull/37

I've implemented this as a `onBefore` rather than an `onAfter` to ensure data is still available to record in the auditor log