### PR TITLE
ENH Remove remember login hash coupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,6 @@ It is also compatible with the [Silverstripe MFA module suite](https://github.co
 
 ## Configuration
 
-### Logout across devices
-
-This module respects the `SilverStripe\Security\RememberLoginHash.logout_across_devices` config setting, which defaults to `true`. This means that the default behaviour is to revoke _all_ a user’s sessions when they log out.
-
-To change this so that logging out will only revoke the session for that one device, use the following config setting:
-
-```yml
-SilverStripe\Security\RememberLoginHash:
-  logout_across_devices: false
-```
-
-**Important:** do not set this value to false if users do not have access to the CMS (or a custom UI where they can revoke sessions). Doing so would make it impossible to a user to revoke a session if they suspect their device has been compromised.
-
 ### Session timeout
 
 Non-persisted login sessions (those where the user hasn’t ticked “remember me”) should expire after a period of inactivity, so that they’re removed from the list of active sessions even if the user closes their browser without completing the “log out” action. The length of time before expiry matches the `SilverStripe\Control\Session.timeout` value if one is set, otherwise falling back to a default of one hour. This default can be changed via the following config setting:

--- a/src/Security/LogOutAuthenticationHandler.php
+++ b/src/Security/LogOutAuthenticationHandler.php
@@ -41,16 +41,10 @@ class LogOutAuthenticationHandler implements AuthenticationHandler
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $member = Security::getCurrentUser();
 
-        if (RememberLoginHash::config()->get('logout_across_devices')) {
-            foreach ($member->LoginSessions() as $session) {
-                $session->delete();
-            }
-        } else {
-            $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
-            $loginSession = LoginSession::get()->byID($loginSessionID);
-            if ($loginSession && $loginSession->canDelete($member)) {
-                $loginSession->delete();
-            }
+        $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
+        $loginSession = LoginSession::get()->byID($loginSessionID);
+        if ($loginSession && $loginSession->canDelete($member)) {
+            $loginSession->delete();
         }
 
         $request->getSession()->clear($loginHandler->getSessionVariable());


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-session-manager/issues/13

Remove coupling with the "remember me" login hash which shouldn't be the responsibility of this module

DON'T MERGE

Once the ui-rendering pr has been merged, retarget and possibly rebase this PR to 1