### PR TITLE
FIX Manage LoginSession when Security::setCurrentUser() is called

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -49,3 +49,13 @@ After: '#coreauthentication'
 ---
 SilverStripe\Security\RememberLoginHash:
   logout_across_devices: false
+---
+Name: session-manager-security
+After: '#coresecurity'
+---
+SilverStripe\Security\Security:
+  extensions:
+    - 'SilverStripe\SessionManager\Extensions\SecurityExtension'
+SilverStripe\Assets\AssetControlExtension:
+  excluded_classes:
+    - 'SilverStripe\SessionManager\Models\LoginSession'

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     ],
     "require": {
         "silverstripe/admin": "^1.7",
-        "silverstripe/framework": "^4.8",
+        "silverstripe/framework": "^4.9",
+        "silverstripe/assets": "^4.9",
         "ua-parser/uap-php": "^3.5"
     },
     "require-dev": {

--- a/src/Extensions/SecurityExtension.php
+++ b/src/Extensions/SecurityExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\SessionManager\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Security\Member;
+use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
+use SilverStripe\SessionManager\Security\LogOutAuthenticationHandler;
+
+class SecurityExtension extends Extension
+{
+    public function updateSetCurrentUser(?Member $member)
+    {
+        if (is_null($member)) {
+            $handler = Injector::inst()->get(LogOutAuthenticationHandler::class);
+            $handler->logOut();
+            return;
+        }
+        $handler = Injector::inst()->get(LogInAuthenticationHandler::class);
+        $handler->logIn($member);
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/recipe-cms/issues/47

It's a little weird calling the handlers directly from an extension.  Code could be made nicer by refactoring out the logic in LogInAuthenticationHandler and LogOutAuthenticationHandler into a new Service class, but I don't think it's worth it at this stage