### PR TITLE
ENH Add ability for admin to revoke all sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ The `LoginSession` tracks the IP address and user agent making the requests
 in order to make different sessions easier to identify in the user interface.
 It does not use changes to this metadata to invalidate sessions.
 
+Logged in users have the ability to see their own active sessions across all devices
+and browsers where they have logged in, and can choose to log out any of those sessions.
+
+Administrators can revoke _all_ active sessions for _all_ users by triggering the `dev/tasks/InvalidateAllSessions`
+task either in the browser or via the CLI. Note that this will also revoke the session
+of the user activating the task, so if this is triggered via the browser, that user
+will need to log back in to perform further actions.
+
 ## Compatibility
 
 The module should work independently of the storage mechanism used for PHP sessions (file-based sticky sessions, file-based sessions on a shared filesystem, [silverstripe/dynamodb](https://github.com/silverstripe/silverstripe-dynamodb), [silverstripe/hybridsessions](https://github.com/silverstripe/silverstripe-hybridsessions)).

--- a/src/Tasks/InvalidateAllSessionsTask.php
+++ b/src/Tasks/InvalidateAllSessionsTask.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\SessionManager\Tasks;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\Security\RememberLoginHash;
+use SilverStripe\SessionManager\Models\LoginSession;
+
+class InvalidateAllSessionsTask extends BuildTask
+{
+    private static string $segment = 'InvalidateAllSessions';
+
+    /**
+     * @var string
+     */
+    protected $title = 'Invalidate All Login Sessions Task';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Removes all login sessions and "remember me" hashes (including yours) from the database';
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request)
+    {
+        LoginSession::get()->removeAll();
+        RememberLoginHash::get()->removeAll();
+        echo "Session removal completed successfully\n";
+    }
+}

--- a/tests/php/Tasks/InvalidateAllSessionsTaskTest.php
+++ b/tests/php/Tasks/InvalidateAllSessionsTaskTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SilverStripe\SessionManager\Tests\Services;
+
+use SilverStripe\Control\Middleware\ConfirmationMiddleware\Url;
+use SilverStripe\Control\Tests\HttpRequestMockBuilder;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Security\AuthenticationHandler;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\RememberLoginHash;
+use SilverStripe\Security\Security;
+use SilverStripe\SessionManager\Extensions\RememberLoginHashExtension;
+use SilverStripe\SessionManager\Middleware\LoginSessionMiddleware;
+use SilverStripe\SessionManager\Models\LoginSession;
+use SilverStripe\SessionManager\Tasks\InvalidateAllSessionsTask;
+
+class InvalidateAllSessionsTaskTest extends SapphireTest
+{
+    use HttpRequestMockBuilder;
+
+    protected static $fixture_file = 'InvalidateAllSessionsTaskTest.yml';
+
+    protected static $required_extensions = [
+        RememberLoginHash::class => [
+            RememberLoginHashExtension::class,
+        ],
+    ];
+
+    public function testRemoveAllSessions()
+    {
+        // Ensure existing fixtured sessions are valid
+        DBDatetime::set_mock_now('2003-02-15 10:00:00');
+
+        // Log in as member 1 and make them active
+        $request = $this->buildRequestMock('dev/tasks/' . InvalidateAllSessionsTask::config()->get('segment'));
+        $request->method('getIP')->willReturn('192.168.0.1');
+        $member = $this->objFromFixture(Member::class, 'member1');
+        $handler = Injector::inst()->get(AuthenticationHandler::class);
+        $handler->login($member, true, $request);
+
+        // Ensure fixtured sessions are created and at least one login hash is generated
+        $this->assertNotSame(0, LoginSession::get()->count(), 'There is at least one LoginSession');
+        $this->assertNotSame(0, RememberLoginHash::get()->count(), 'There is at least one RememberLoginHash');
+
+        // Completely invalidate all current sessions and login hashes
+        $task = new InvalidateAllSessionsTask();
+        $task->run($request);
+
+        // Assert all sessions are removed from the database
+        $this->assertSame(0, LoginSession::get()->count(), 'There are no LoginSessions');
+        $this->assertSame(0, RememberLoginHash::get()->count(), 'There are no RememberLoginHashes');
+
+        // Navigate to re-validate current session
+        $middleware = new LoginSessionMiddleware(new Url('no-match'));
+        $next = false;
+        $middleware->process(
+            $request,
+            function () {
+                // no-op
+            }
+        );
+        // Assert user who initiated the request's session was also invalidated
+        $this->assertNull(
+            Security::getCurrentUser(),
+            'User was logged out because their session was invalidated'
+        );
+    }
+}

--- a/tests/php/Tasks/InvalidateAllSessionsTaskTest.yml
+++ b/tests/php/Tasks/InvalidateAllSessionsTaskTest.yml
@@ -1,0 +1,26 @@
+SilverStripe\Security\Member:
+  member1:
+    FirstName: 'Andre'
+    Email: 'andre@example.org'
+  member_rmh:
+    FirstName: 'Bob'
+    Email: 'bob@example.com'
+
+SilverStripe\SessionManager\Models\LoginSession:
+  x1:
+    LastAccessed: '2003-02-15 10:00:00'
+    IPAddress: '192.168.0.1'
+    Member: =>SilverStripe\Security\Member.member1
+    Persistent: true
+  x2:
+    LastAccessed: '2003-02-15 10:00:00'
+    IPAddress: '192.168.0.1'
+    Member: =>SilverStripe\Security\Member.member_rmh
+    Persistent: false
+  x3:
+    LastAccessed: '2003-02-15 10:00:00'
+    IPAddress: '192.168.0.14'
+    Member: =>SilverStripe\Security\Member.member_rmh
+  orphan:
+    LastAccessed: '2003-02-15 10:00:00'
+    IPAddress: '192.168.0.1'


### PR DESCRIPTION
Note that the `onBeforeRemoveLoginSession` extension hook (see `LoginSessionController::remove()`) is not called. The thinking is that this task is effectively for emergency situations anyway to prevent an identified actively logged in potential attacker from making additional changes - the aim is to outright remove all current sessions.
This is also consistent with the `GarbageCollectionTask`. 

## Acceptance criteria (from parent issue, for the sake of transparency)
- Create a new task on session manager that invalidates all sessions.
- The task can only be run run by admin
  - In this case this is handled by the regular permission check that prevents non-admin from calling dev tasks on production
- Task invalidates all sessions, including the one of the user running it.
- Validates what happens if you destroy a thousand session in one go.
  - Checked by creating a temporary task that created a thousand sessions, then running the new task in the browser. Worked fine. Not sure that a unit test is required for this but I can see about adding one if someone disagrees.
- Validates that remember me token don't allow you to login anymore.
  - The actual tests for this is `SilverStripe\Security\Tests\RememberLoginHashTest::testClear()` in framework - for the purposes of this PR, testing that they're removed is sufficient.
- Validates that this work with hybrid sessions as well.
  - Checked manually in browser and by running the tests with hybrid sessions installed. I'm not sure where we'd add unit tests for this if we were to add them.

## Parent issue:
- silverstripeltd/product-issues#525