### PR TITLE
Removed two out-of-date translation strings

### DIFF
--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,7 +1,5 @@
 nl:
   SilverStripe\SessionManager\Controllers\LoginSessionController:
-    REMOVE_FAILURE: ''
-    REMOVE_PERMISSION: ''
     REMOVE_SUCCESS: 'Sessie is succesvol verwijderd.'
     INVALID_REQUEST: 'Ongeldige aanroep'
     SESSION_COULD_NOT_BE_FOUND_OR_NO_LONGER_ACTIVE: 'Deze sessie kon niet gevonden worden of was niet meer geldig.'


### PR DESCRIPTION
Strings don't seem to be used in LoginSessionController anymore.
Other empty strings have all been filled so #114 can probably be closed.