### PR TITLE
use orm cache in SessionManagerField

### DIFF
--- a/src/FormFields/SessionManagerField.php
+++ b/src/FormFields/SessionManagerField.php
@@ -127,7 +127,7 @@ class SessionManagerField extends FormField
             if (!$loginSession->canView()) {
                 continue;
             }
-            
+
             $member = DataObject::get_by_id(Member::class, $loginSession->MemberID);
 
             $loginSessions[] = [

--- a/src/FormFields/SessionManagerField.php
+++ b/src/FormFields/SessionManagerField.php
@@ -128,7 +128,6 @@ class SessionManagerField extends FormField
                 continue;
             }
 
-            $member = DataObject::get_by_id(Member::class, $loginSession->MemberID);
 
             $loginSessions[] = [
                 'ID' => $loginSession->ID,

--- a/src/FormFields/SessionManagerField.php
+++ b/src/FormFields/SessionManagerField.php
@@ -127,6 +127,9 @@ class SessionManagerField extends FormField
             if (!$loginSession->canView()) {
                 continue;
             }
+            
+            $member = DataObject::get_by_id(Member::class, $loginSession->MemberID);
+
             $loginSessions[] = [
                 'ID' => $loginSession->ID,
                 'IPAddress' => $loginSession->IPAddress,
@@ -134,7 +137,7 @@ class SessionManagerField extends FormField
                 'IsCurrent' => $loginSession->isCurrent(),
                 'Persistent' => $loginSession->Persistent,
                 'Member' => [
-                    'Name' => $loginSession->Member()->Name
+                    'Name' => $member->Name
                 ],
                 'Created' => $this->addUtcOffset($loginSession->Created),
                 'LastAccessed' => $this->addUtcOffset($loginSession->LastAccessed),

--- a/src/FormFields/SessionManagerField.php
+++ b/src/FormFields/SessionManagerField.php
@@ -137,7 +137,7 @@ class SessionManagerField extends FormField
                 'IsCurrent' => $loginSession->isCurrent(),
                 'Persistent' => $loginSession->Persistent,
                 'Member' => [
-                    'Name' => $member->Name
+                    'Name' => Member::get_by_id($loginSession->MemberID)->Name ?? ''
                 ],
                 'Created' => $this->addUtcOffset($loginSession->Created),
                 'LastAccessed' => $this->addUtcOffset($loginSession->LastAccessed),


### PR DESCRIPTION
calling ->Member on distinct object is never going to trigger ORM cache. Since the member is expected to be always the same, this leads to duplicate queries