### PR TITLE
use orm cache in LoginSession

### DIFF
--- a/src/Models/LoginSession.php
+++ b/src/Models/LoginSession.php
@@ -260,7 +260,7 @@ class LoginSession extends DataObject
 
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
-        $loginSession = LoginSession::get()->byID($loginSessionID);
+        $loginSession = DataObject::get_by_id(LoginSession::class, $loginSessionID);
         return $loginSession;
     }
 

--- a/src/Models/LoginSession.php
+++ b/src/Models/LoginSession.php
@@ -260,7 +260,7 @@ class LoginSession extends DataObject
 
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
-        $loginSession = DataObject::get_by_id(LoginSession::class, $loginSessionID);
+        $loginSession = LoginSession::get_by_id($loginSessionID);
         return $loginSession;
     }
 


### PR DESCRIPTION
calls to isCurrent do not benefit from cache when byID is used

<img width="874" alt="image" src="https://github.com/silverstripe/silverstripe-session-manager/assets/250762/2f82400f-2c09-4909-81eb-7bbb3c311059">
