### PR TITLE
Fix mock time in GarbageCollection test

### DIFF
--- a/src/Services/GarbageCollectionService.php
+++ b/src/Services/GarbageCollectionService.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\SessionManager\Services;
 
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\SessionManager\Models\LoginSession;
 
@@ -26,11 +27,11 @@ class GarbageCollectionService
     private function collectExpiredSessions(): void
     {
         $lifetime = LoginSession::config()->get('default_session_lifetime');
-        $sessions = LoginSession::get()->filter([
-            'LastAccessed:LessThan' => date('Y-m-d H:i:s', time() - $lifetime),
+        $now = DBDatetime::now()->getTimestamp() - $lifetime;
+        LoginSession::get()->filter([
+            'LastAccessed:LessThan' => date('Y-m-d H:i:s', $now),
             'Persistent' => 0
-        ]);
-        $sessions->removeAll();
+        ])->removeAll();
     }
 
     /**
@@ -38,9 +39,19 @@ class GarbageCollectionService
      */
     private function collectImplicitlyExpiredSessions(): void
     {
+        $now = DBDatetime::now()->getTimestamp();
         LoginSession::get()->filter([
             'Persistent' => 1,
-            'LoginHash.ExpiryDate:LessThan' => date('Y-m-d H:i:s')
+            'LoginHash.ExpiryDate:LessThan' => date('Y-m-d H:i:s', $now),
+        ])->removeAll();
+
+        $lifetime = LoginSession::config()->get('default_session_lifetime');
+        $now = DBDatetime::now()->getTimestamp() - $lifetime;
+        // If a persistent session has no login hash, use LastAccessed
+        LoginSession::get()->filter([
+            'LastAccessed:LessThan' => date('Y-m-d H:i:s', $now),
+            'Persistent' => 1,
+            'LoginHash.ExpiryDate' => null,
         ])->removeAll();
     }
 
@@ -49,8 +60,9 @@ class GarbageCollectionService
      */
     private function collectExpiredLoginHashes(): void
     {
+        $now = DBDatetime::now()->getTimestamp();
         RememberLoginHash::get()->filter([
-            'ExpiryDate:LessThan' => date('Y-m-d H:i:s')
+            'ExpiryDate:LessThan' => date('Y-m-d H:i:s', $now),
         ])->removeAll();
     }
 }

--- a/tests/php/Services/GarbageCollectionServiceTest.php
+++ b/tests/php/Services/GarbageCollectionServiceTest.php
@@ -21,7 +21,7 @@ class GarbageCollectionServiceTest extends SapphireTest
 
     public function testGarbageCollection()
     {
-        DBDatetime::set_mock_now('2003-08-15 12:00:00');
+        DBDatetime::set_mock_now('2003-05-16 12:00:00');
 
         $id1 = $this->objFromFixture(LoginSession::class, 'x1')->ID;
         $id2 = $this->objFromFixture(LoginSession::class, 'x2')->ID;
@@ -34,13 +34,29 @@ class GarbageCollectionServiceTest extends SapphireTest
             LoginSession::get()->byID($id1),
             "Expired login session is deleted"
         );
+        // ExpiryDate for the hash is set to '2003-05-15 10:00:00' => it should be deleted
         $this->assertNull(
             LoginSession::get()->byID($id2),
             "Expired persistent login hash session is deleted"
         );
+        // LastAccessed is set to '2004-02-15 10:00:00' => it should not be deleted
         $this->assertNotNull(
             LoginSession::get()->byID($id3),
             "Valid login session is not deleted"
+        );
+        $this->assertEquals(
+            0,
+            LoginSession::get()->byID($id3)->LoginHash()->ID,
+            "Hash is deleted but session is still valid"
+        );
+
+        DBDatetime::set_mock_now('2005-08-15 12:00:00');
+
+        $garbageCollectionService->collect();
+
+        $this->assertNull(
+            LoginSession::get()->byID($id3),
+            "Login session is now deleted"
         );
     }
 }

--- a/tests/php/Services/GarbageCollectionServiceTest.php
+++ b/tests/php/Services/GarbageCollectionServiceTest.php
@@ -39,7 +39,7 @@ class GarbageCollectionServiceTest extends SapphireTest
             LoginSession::get()->byID($id2),
             "Expired persistent login hash session is deleted"
         );
-        // LastAccessed is set to '2004-02-15 10:00:00' => it should not be deleted
+        // LastAccessed is set to '2004-02-15 10:00:00' and it has no hash => it should not be deleted
         $this->assertNotNull(
             LoginSession::get()->byID($id3),
             "Valid login session is not deleted"
@@ -47,7 +47,7 @@ class GarbageCollectionServiceTest extends SapphireTest
         $this->assertEquals(
             0,
             LoginSession::get()->byID($id3)->LoginHash()->ID,
-            "Hash is deleted but session is still valid"
+            "There is no hash but session is still valid"
         );
 
         DBDatetime::set_mock_now('2005-08-15 12:00:00');
@@ -56,7 +56,7 @@ class GarbageCollectionServiceTest extends SapphireTest
 
         $this->assertNull(
             LoginSession::get()->byID($id3),
-            "Login session is now deleted"
+            "Persistent Login session is now deleted"
         );
     }
 }


### PR DESCRIPTION
i don't know if it's fully intentional that a persistent login hash can be deleted while the session is still valid, but anyways, here it goes :-)

by changing the mock time, we can show that a persisted session should be cleared if LastAccesed + session lifetime < now
(or should not be cleared, if the persistent session without a hash is meant to stay => not what i did here, but i can revert that part if needed)

fixes https://github.com/silverstripe/silverstripe-session-manager/issues/154