### PR TITLE
API Use new RememberLoginHash::onAfterRenewSession extension point

### DIFF
--- a/src/Extensions/RememberLoginHashExtension.php
+++ b/src/Extensions/RememberLoginHashExtension.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\SessionManager\Models\LoginSession;
 use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
+use SilverStripe\SessionManager\Middleware\LoginSessionMiddleware;
 
 /**
  * @method LoginSession LoginSession()
@@ -33,9 +34,15 @@ class RememberLoginHashExtension extends Extension
     }
 
     /**
+     * Overwrites the core session variable with the LoginSession record ID
+     * during session renewal when the user selects 'remember me' (ALC).
+     * This works in tandem with LoginSessionMiddleware, and avoids the
+     * overhead of an additional DB query.
+     *
+     * @see LoginSessionMiddleware
      * @return void
      */
-    protected function onAfterRenewToken(): void
+    protected function onAfterRenewSession(): void
     {
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $request = Injector::inst()->get(HTTPRequest::class);

--- a/src/Middleware/LoginSessionMiddleware.php
+++ b/src/Middleware/LoginSessionMiddleware.php
@@ -31,6 +31,8 @@ class LoginSessionMiddleware implements HTTPMiddleware
         }
 
         try {
+            // Extract the session identifier (when this module is installed, the session identifier is set to the
+            // LoginSession ID rather than the RememberLoginHash ID, to avoid an extra query to get the related model.)
             $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
             $loginSession = LoginSession::get_by_id($loginSessionID);
 

--- a/src/Security/LogInAuthenticationHandler.php
+++ b/src/Security/LogInAuthenticationHandler.php
@@ -100,6 +100,8 @@ class LogInAuthenticationHandler implements AuthenticationHandler
             $rememberLoginHash->write();
         }
 
+        // Overwrite the session identifier, storing the LoginSession ID instead of the RememberLoginHash ID.
+        // This is read by LoginSessionMiddleware, and avoids an extra query to fetch the related model.
         if ($request) {
             $request->getSession()->set($this->getSessionVariable(), $loginSession->ID);
         }


### PR DESCRIPTION
## Description

This extension point is triggered at the same step as the now-removed `onAfterRenewToken` extension point, which was replaced to reflect that the token is no longer rotated when a session renewal is triggered.

I've also added some comments to more clearly articulate the session identifier replacement logic - I considered pulling this out instead, but for efficiency it makes sense to retain.

Co-dependent on related framework PR: silverstripe/silverstripe-framework#11355

## Manual testing steps

Checkout this PR along with the Framework PR and validate that remember me functionality is intact.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- silverstripe/silverstripe-framework#11281

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
