### PR TITLE
MNT Update behat test for sudo mode (backport)

### DIFF
--- a/tests/behat/features/revoke.feature
+++ b/tests/behat/features/revoke.feature
@@ -6,7 +6,8 @@ Feature: See other devices and revoke their access
   So that I can revoke their access
 
   Background:
-    Given a "group" "AUTHOR" has permissions "Access to 'Pages' section"
+    Given I add an extension "SilverStripe\BehatExtension\Extensions\ActivateSudoModeServiceExtension" to the "SilverStripe\Security\SudoMode\SudoModeService" class
+    And a "group" "AUTHOR" has permissions "Access to 'Pages' section"
     And I am logged in as a member of "AUTHOR" group
     # Create a mock login session
     And There is a login session for a second device


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/368

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/13642912411/job/38136393143#step:12:196

Backport cherry-pick of https://github.com/silverstripe/silverstripe-session-manager/pull/232

session-manager isn't getting a new minor as part of CMS 5.4.0, so we need to update the behat test on the current minor branch
