### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/Middleware/LoginSessionMiddlewareTest.php
+++ b/tests/php/Middleware/LoginSessionMiddlewareTest.php
@@ -175,7 +175,7 @@ class LoginSessionMiddlewareTest extends SapphireTest
         $middleware->process($request, function () {
             // noop
         });
-        Cookie::set('alc_device', $default);
+        Cookie::set('alc_device', $default ?? '');
 
         $this->assertSame(1, RememberLoginHash::get()->filter($deviceFilter)->count());
         $this->assertSame(


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-session-manager/actions/runs/13912738749/job/39005406972

```text
1) SilverStripe\SessionManager\Tests\Middleware\LoginSessionMiddlewareTest::testOtherDeviceRememberLoginHashUntouched
TypeError: SilverStripe\Control\Cookie::set(): Argument #2 ($value) must be of type string|false, null given, called in /home/runner/work/silverstripe-session-manager/silverstripe-session-manager/tests/php/Middleware/LoginSessionMiddlewareTest.php on line 178
```

## Issue
- https://github.com/silverstripe/.github/issues/378