### PR TITLE
DEP Replace `ua-parser/uap-php` with `donatj/phpuseragentparser`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "silverstripe/admin": "^3",
         "silverstripe/framework": "^6",
         "symfony/http-foundation": "^7.0",
-        "ua-parser/uap-php": "^3.9.14"
+        "donatj/phpuseragentparser": "^1.10"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4",

--- a/src/Models/LoginSession.php
+++ b/src/Models/LoginSession.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\SessionManager\Models;
 
-use UAParser\Parser;
 use InvalidArgumentException;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
@@ -16,6 +15,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\SessionManager\Security\LogInAuthenticationHandler;
 use Symfony\Component\HttpFoundation\IpUtils;
+use donatj\UserAgent\UserAgentParser;
 
 /**
  * Tracks a login session for a specific user on a specific device.
@@ -247,13 +247,13 @@ class LoginSession extends DataObject
             return '';
         }
 
-        $parser = Parser::create();
+        $parser = Injector::inst()->create(UserAgentParser::class);
         $result = $parser->parse($this->UserAgent);
 
         return _t(
             __CLASS__ . '.BROWSER_ON_OS',
             "{browser} on {os}.",
-            ['browser' => $result->ua->family, 'os' => $result->os->toString()]
+            ['browser' => $result->browser(), 'os' => $result->platform()]
         );
     }
 

--- a/tests/php/LoginSessionTest.yml
+++ b/tests/php/LoginSessionTest.yml
@@ -35,3 +35,7 @@ SilverStripe\SessionManager\Models\LoginSession:
   orphan:
     LastAccessed: '2003-02-15 10:00:00'
     IPAddress: '192.168.0.1'
+  firefox:
+    UserAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
+  chrome:
+    UserAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'

--- a/tests/php/Models/LoginSessionTest.php
+++ b/tests/php/Models/LoginSessionTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SessionManager\Tests\Extensions;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SessionManager\Models\LoginSession;
 
@@ -95,5 +96,26 @@ class LoginSessionTest extends SapphireTest
         $this->assertFalse($session->canView(), 'Anonymous can not view');
         $this->assertFalse($session->canEdit(), 'Anonymous can not edit');
         $this->assertFalse($session->canDelete(), 'Anonymous can not delete');
+    }
+
+    public static function provideGetFriendlyUserAgent(): array
+    {
+        return [
+            [
+                'fixtureName' => 'firefox',
+                'expected' => 'Firefox on Linux.',
+            ],
+            [
+                'fixtureName' => 'chrome',
+                'expected' => 'Chrome on Windows.',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetFriendlyUserAgent')]
+    public function testGetFriendlyUserAgent(string $fixtureName, string $expected): void
+    {
+        $session = $this->objFromFixture(LoginSession::class, $fixtureName);
+        $this->assertSame($expected, $session->getFriendlyUserAgent());
     }
 }


### PR DESCRIPTION
[ua-parser/uap-php](https://github.com/ua-parser/uap-php/) appears to be abandoned and has not merged a PR necessary for PHP 8.4 compatibility.
[donatj/phpuseragentparser](https://github.com/donatj/PhpUserAgent) seems to update reasonably frequently, is fairly widely used, and is PHP 8.4 compatible.

This is only used for displaying the browser and OS of a user agent to the user, and does not affect any functional logic. It appears to be a safe substitution to make. No API is broken and this doesn't affect our [fixed dependencies](https://docs.silverstripe.org/en/6/project_governance/fixed_dependencies/) so is safe to do from a release policy perspective as a fix without needing product owner approval.

## Issue

- https://github.com/silverstripe/.github/issues/351