### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/admin": "^3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "symfony/http-foundation": "^7.0",
         "donatj/phpuseragentparser": "^1.10"
     },

--- a/src/FormFields/SessionManagerField.php
+++ b/src/FormFields/SessionManagerField.php
@@ -102,7 +102,7 @@ class SessionManagerField extends FormField
         if (!$this->value && $this->getForm() && $this->getForm()->getRecord() instanceof Member) {
             $member = $this->getForm()->getRecord();
         } else {
-            $member = DataObject::get_by_id(Member::class, $this->value);
+            $member = Member::get()->setUseCache(true)->byID($this->value);
         }
 
         return array_merge($defaults, [
@@ -134,7 +134,7 @@ class SessionManagerField extends FormField
                 'IsCurrent' => $loginSession->isCurrent(),
                 'Persistent' => $loginSession->Persistent,
                 'Member' => [
-                    'Name' => Member::get_by_id($loginSession->MemberID)->Name ?? ''
+                    'Name' => Member::get()->setUseCache(true)->byID($loginSession->MemberID)->Name ?? ''
                 ],
                 'Created' => $this->addUtcOffset($loginSession->Created),
                 'LastAccessed' => $this->addUtcOffset($loginSession->LastAccessed),

--- a/src/Middleware/LoginSessionMiddleware.php
+++ b/src/Middleware/LoginSessionMiddleware.php
@@ -34,7 +34,7 @@ class LoginSessionMiddleware implements HTTPMiddleware
             // Extract the session identifier (when this module is installed, the session identifier is set to the
             // LoginSession ID rather than the RememberLoginHash ID, to avoid an extra query to get the related model.)
             $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
-            $loginSession = LoginSession::get_by_id($loginSessionID);
+            $loginSession = LoginSession::get()->setUseCache(true)->byID($loginSessionID);
 
             // If the session has already been revoked, or we've got a mismatched
             // member / session, log the user out (this also revokes the session)

--- a/src/Models/LoginSession.php
+++ b/src/Models/LoginSession.php
@@ -278,7 +278,7 @@ class LoginSession extends DataObject
 
         $loginHandler = Injector::inst()->get(LogInAuthenticationHandler::class);
         $loginSessionID = $request->getSession()->get($loginHandler->getSessionVariable());
-        $loginSession = LoginSession::get_by_id($loginSessionID);
+        $loginSession = LoginSession::get()->setUseCache(true)->byID($loginSessionID);
         return $loginSession;
     }
 


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
