### PR TITLE
Fix: type casting for LastAccessed comparison

### DIFF
--- a/src/Middleware/LoginSessionMiddleware.php
+++ b/src/Middleware/LoginSessionMiddleware.php
@@ -48,7 +48,7 @@ class LoginSessionMiddleware implements HTTPMiddleware
             // Update LastAccessed date and IP address if > that threshold
             $date = DBDatetime::now()->Rfc2822();
             $threshold = LoginSession::config()->get('last_accessed_threshold');
-            if (strtotime($date) > strtotime($loginSession->LastAccessed) + $threshold) {
+            if (strtotime($date) > strtotime((string) $loginSession->LastAccessed) + $threshold) {
                 $loginSession->updateLastAccessed($request);
             }
         } catch (DatabaseException $e) {


### PR DESCRIPTION

## Description

String methods should force string to avoid errors

## Manual testing steps

Run a task from the command line that uses this code. Then you get this error:
```shell
ERROR [Deprecated]: strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated
IN GET /
Line 51 in /var/www/ss4/wremo.nz/vendor/silverstripe/session-manager/src/Middleware/LoginSessionMiddleware.php

Source
======
  42:                  RememberLoginHash::setLogoutAcrossDevices(false);
  43:                  $identityStore = Injector::inst()->get(IdentityStore::class);
  44:                  $identityStore->logOut($request);
  45:                  return $delegate($request);
  46:              }
  47:  
  48:              // Update LastAccessed date and IP address if > that threshold
  49:              $date = DBDatetime::now()->Rfc2822();
  50:              $threshold = LoginSession::config()->get('last_accessed_threshold');
* 51:              if (strtotime($date) > strtotime($loginSession->LastAccessed) + $threshold) {
  52:                  $loginSession->updateLastAccessed($request);
  53:              }
  54:          } catch (DatabaseException $e) {
  55:              // Database isn't ready, carry on.
  56:          }
  57:  

Trace
=====
strtotime()
LoginSessionMiddleware.php:51

SilverStripe\SessionManager\Middleware\LoginSessionMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
ExecMetricMiddleware.php:20

SilverStripe\Control\Middleware\ExecMetricMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
ConfirmationMiddleware.php:254

SilverStripe\Control\Middleware\ConfirmationMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
ConfirmationMiddleware.php:254

SilverStripe\Control\Middleware\ConfirmationMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
PasswordExpirationMiddleware.php:84

SilverStripe\Security\PasswordExpirationMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
BasicAuthMiddleware.php:68

SilverStripe\Security\BasicAuthMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
AuthenticationMiddleware.php:61

SilverStripe\Security\AuthenticationMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
CanonicalURLMiddleware.php:247

SilverStripe\Control\Middleware\CanonicalURLMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
HTTPCacheControlMiddleware.php:46

SilverStripe\Control\Middleware\HTTPCacheControlMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
ChangeDetectionMiddleware.php:28

SilverStripe\Control\Middleware\ChangeDetectionMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
HybridSessionMiddleware.php:18

SilverStripe\HybridSessions\Control\HybridSessionMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
AllowedHostsMiddleware.php:71

SilverStripe\Control\Middleware\AllowedHostsMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
TrustedProxyMiddleware.php:179

SilverStripe\Control\Middleware\TrustedProxyMiddleware->process(SilverStripe\Control\HTTPRequest, Closure)
HTTPMiddlewareAware.php:62

SilverStripe\Control\Director->SilverStripe\Control\Middleware\{closure}(SilverStripe\Control\HTTPRequest)
HTTPMiddlewareAware.php:65

SilverStripe\Control\Director->callMiddleware(SilverStripe\Control\HTTPRequest, Closure)
Director.php:382

SilverStripe\Control\Director->handleRequest(SilverStripe\Control\HTTPRequest)
Director.php:133

SilverStripe\Control\Director::SilverStripe\Control\{closure}(SilverStripe\Control\HTTPRequest)

call_user_func(Closure, SilverStripe\Control\HTTPRequest)
Director.php:277

SilverStripe\Control\Director::mockRequest(Closure, , Array, SilverStripe\Control\Session, , , Array, Array, SilverStripe\Control\HTTPRequest)
Director.php:131

SilverStripe\Control\Director::test(/, Array, SilverStripe\Control\Session)
CheckAllTemplatesFromCli.php:277

Sunnysideup\TemplateOverview\Tasks\CheckAllTemplatesFromCli->fetchWithRedirects(/, http://wremo.nz.ss4/)
CheckAllTemplatesFromCli.php:199

Sunnysideup\TemplateOverview\Tasks\CheckAllTemplatesFromCli->checkLink(/, Array, , SilverStripe\PolyExecution\PolyOutput)
CheckAllTemplatesFromCli.php:106

Sunnysideup\TemplateOverview\Tasks\CheckAllTemplatesFromCli->execute(SilverStripe\Cli\LegacyParamArgvInput, SilverStripe\PolyExecution\PolyOutput)
BuildTask.php:69

SilverStripe\Dev\BuildTask->run(SilverStripe\Cli\LegacyParamArgvInput, SilverStripe\PolyExecution\PolyOutput)
PolyCommandCliWrapper.php:39

SilverStripe\Cli\Command\PolyCommandCliWrapper->execute(SilverStripe\Cli\LegacyParamArgvInput, Symfony\Component\Console\Output\ConsoleOutput)
Command.php:341

Symfony\Component\Console\Command\Command->run(SilverStripe\Cli\LegacyParamArgvInput, Symfony\Component\Console\Output\ConsoleOutput)
Application.php:1117

Symfony\Component\Console\Application->doRunCommand(SilverStripe\Cli\Command\PolyCommandCliWrapper, SilverStripe\Cli\LegacyParamArgvInput, Symfony\Component\Console\Output\ConsoleOutput)
Sake.php:219

SilverStripe\Cli\Sake->doRunCommand(SilverStripe\Cli\Command\PolyCommandCliWrapper, SilverStripe\Cli\LegacyParamArgvInput, Symfony\Component\Console\Output\ConsoleOutput)
Application.php:356

Symfony\Component\Console\Application->doRun(SilverStripe\Cli\LegacyParamArgvInput, Symfony\Component\Console\Output\ConsoleOutput)
Application.php:195

Symfony\Component\Console\Application->run(SilverStripe\Cli\LegacyParamArgvInput, Symfony\Component\Console\Output\ConsoleOutput)
Sake.php:118

SilverStripe\Cli\Sake->run()
sake:19
```

## Issues

No recent issues

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
